### PR TITLE
Ensure case-sensitive login and handle /b in home menus

### DIFF
--- a/src/main/java/com/chatmulticanale/db/chat-multicanale_schema.sql
+++ b/src/main/java/com/chatmulticanale/db/chat-multicanale_schema.sql
@@ -612,8 +612,8 @@ BEGIN
         Nome_Utente,
         Cognome_Utente,
         Ruolo
-    FROM Utente 
-    WHERE Username = p_Username;
+    FROM Utente
+    WHERE BINARY Username = BINARY p_Username;
 END$$
 
 DELIMITER ;

--- a/src/main/java/com/chatmulticanale/view/AmministrazioneView.java
+++ b/src/main/java/com/chatmulticanale/view/AmministrazioneView.java
@@ -37,7 +37,16 @@ public class AmministrazioneView implements View {
             ViewUtils.println(CostantiView.HOME_AMMINISTRATORE_OPZIONE_0);
             ViewUtils.printSeparator();
 
-            int scelta = InputUtils.readIntInRange(CostantiView.SELEZIONA_OPZIONE, 0, 5);
+            int scelta;
+            try {
+                scelta = InputUtils.readIntInRange(CostantiView.SELEZIONA_OPZIONE, 0, 5);
+            } catch (CommandException e) {
+                if (e.getNavigazione().azione == Navigazione.Azione.LOGOUT) {
+                    return e.getNavigazione();
+                }
+                ViewUtils.println(ColorUtils.ANSI_RED + "Errore: Inserisci un numero valido." + ColorUtils.ANSI_RESET);
+                continue;
+            }
             switch (scelta) {
                 case 1:
                     handlePromuoviUtente();

--- a/src/main/java/com/chatmulticanale/view/CapoProgettoView.java
+++ b/src/main/java/com/chatmulticanale/view/CapoProgettoView.java
@@ -47,7 +47,16 @@ public class CapoProgettoView implements View {
             ViewUtils.println(CostantiView.HOME_CAPO_PROGETTO_OPZIONE_0);
             ViewUtils.printSeparator();
 
-            int scelta = InputUtils.readIntInRange(CostantiView.SELEZIONA_OPZIONE, 0, 6);
+            int scelta;
+            try {
+                scelta = InputUtils.readIntInRange(CostantiView.SELEZIONA_OPZIONE, 0, 6);
+            } catch (CommandException e) {
+                if (e.getNavigazione().azione == Navigazione.Azione.LOGOUT) {
+                    return e.getNavigazione();
+                }
+                ViewUtils.println(ColorUtils.ANSI_RED + "Errore: Inserisci un numero valido." + ColorUtils.ANSI_RESET);
+                continue;
+            }
 
             switch (scelta) {
                 case 1:

--- a/src/main/java/com/chatmulticanale/view/DipendenteView.java
+++ b/src/main/java/com/chatmulticanale/view/DipendenteView.java
@@ -33,7 +33,16 @@ public class DipendenteView implements View {
             ViewUtils.println(CostantiView.HOME_DIPENDENTE_OPZIONE_0);
             ViewUtils.printSeparator();
 
-            int scelta = InputUtils.readIntInRange(CostantiView.SELEZIONA_OPZIONE, 0, 1);
+            int scelta;
+            try {
+                scelta = InputUtils.readIntInRange(CostantiView.SELEZIONA_OPZIONE, 0, 1);
+            } catch (CommandException e) {
+                if (e.getNavigazione().azione == Navigazione.Azione.LOGOUT) {
+                    return e.getNavigazione();
+                }
+                ViewUtils.println(ColorUtils.ANSI_RED + "Errore: Inserisci un numero valido." + ColorUtils.ANSI_RESET);
+                continue;
+            }
 
             switch (scelta) {
                 case 1:

--- a/src/main/java/com/chatmulticanale/view/WelcomeView.java
+++ b/src/main/java/com/chatmulticanale/view/WelcomeView.java
@@ -2,6 +2,7 @@ package com.chatmulticanale.view;
 
 import com.chatmulticanale.controller.LoginController;
 import com.chatmulticanale.controller.SignUpController; // <-- NUOVO IMPORT
+import com.chatmulticanale.exception.CommandException;
 import com.chatmulticanale.utils.ColorUtils;
 import com.chatmulticanale.utils.InputUtils;
 import com.chatmulticanale.utils.ViewUtils;
@@ -36,7 +37,17 @@ public class WelcomeView implements View {
             ViewUtils.println("1. Login");
             ViewUtils.println("2. Registrati (come Dipendente)");
             ViewUtils.println("0. Esci dall'applicazione");
-            int scelta = InputUtils.readIntInRange("Scelta: ", 0, 2);
+
+            int scelta;
+            try {
+                scelta = InputUtils.readIntInRange("Scelta: ", 0, 2);
+            } catch (CommandException e) {
+                if (e.getNavigazione().azione == Navigazione.Azione.LOGOUT) {
+                    return e.getNavigazione();
+                }
+                ViewUtils.println(ColorUtils.ANSI_RED + "Errore: Inserisci un numero valido." + ColorUtils.ANSI_RESET);
+                continue;
+            }
 
             switch (scelta) {
                 case 1:


### PR DESCRIPTION
## Summary
- enforce case-sensitive username check in the login stored procedure
- treat `/b` as invalid input in main menus and keep `/q` working

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685904207374833187c5333fdaae2877